### PR TITLE
Add install make target in CMake script

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,16 @@ set(library_sources ${sources})
 list(REMOVE_ITEM library_sources ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
 add_library(quadprog STATIC ${library_sources} ${headers})
 set_property(TARGET quadprog PROPERTY POSITION_INDEPENDENT_CODE 1)
+set_property(TARGET quadprog PROPERTY PUBLIC_HEADER ${headers})
 
 add_executable(main main.cc ${headers})
 target_link_libraries(main quadprog)
+
+install(TARGETS quadprog
+  EXPORT quadprog-targets
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include/QuadProg++
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
+
+install(EXPORT quadprog-targets DESTINATION cmake)


### PR DESCRIPTION
Add install script for users to do
```
cmake --build . --target Install
```
Users can then import the library later by writing
```cmake
target_link_libraries (project_name quadprog)
```
in their CMakeLists.txt.