### PR TITLE
Remove an unused variable declaration

### DIFF
--- a/src/QuadProg++.cc
+++ b/src/QuadProg++.cc
@@ -481,7 +481,7 @@ inline void update_z(Vector<double>& z, const Matrix<double>& J, const Vector<do
 
 inline void update_r(const Matrix<double>& R, Vector<double>& r, const Vector<double>& d, int iq)
 {
-  register int i, j, n = d.size();
+  register int i, j;
   register double sum;
   
   /* setting of r = R^-1 d */


### PR DESCRIPTION
The variable `n` in Line 484 seems not to be used, and it generates the following warning: 
```
[...]/QuadProgpp/src/QuadProg++.cc:484:22: warning: unused variable 'n' [-Wunused-variable]
  register int i, j, n = d.size();
                     ^
1 warning generated.
```
I would like to just remove `n` from that line.