### PR TITLE
Remove "register" from public headers for C++17

### DIFF
--- a/src/Array.hh
+++ b/src/Array.hh
@@ -909,10 +909,9 @@ template <typename T>
 Matrix<T>::Matrix(unsigned int n, unsigned int m)
   : v(new T*[n])
 {
-  unsigned int i;
   this->n = n; this->m = m;
   v[0] = new T[m * n];
-  for (i = 1; i < n; i++)
+  for (unsigned int i = 1; i < n; i++)
     v[i] = v[i - 1] + m;
 }
 
@@ -920,13 +919,12 @@ template <typename T>
 Matrix<T>::Matrix(const T& a, unsigned int n, unsigned int m)
   : v(new T*[n])
 {
-  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n];
-  for (i = 1; i < n; i++)
+  for (unsigned int i = 1; i < n; i++)
     v[i] = v[i - 1] + m;
-  for (i = 0; i < n; i++)
-    for (j = 0; j < m; j++)
+  for (unsigned int i = 0; i < n; i++)
+    for (unsigned int j = 0; j < m; j++)
       v[i][j] = a;
 }
 
@@ -934,13 +932,12 @@ template <class T>
 Matrix<T>::Matrix(const T* a, unsigned int n, unsigned int m) 
   : v(new T*[n])
 { 
-  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n]; 
-  for (i = 1; i < n; i++) 
+  for (unsigned int i = 1; i < n; i++)
     v[i] = v[i - 1] + m; 
-  for (i = 0; i < n; i++) 
-    for (j = 0; j < m; j++) 
+  for (unsigned int i = 0; i < n; i++)
+    for (unsigned int j = 0; j < m; j++)
       v[i][j] = *a++; 
 } 
 
@@ -948,16 +945,15 @@ template <class T>
 Matrix<T>::Matrix(MType t, const T& a, const T& o, unsigned int n, unsigned int m) 
   : v(new T*[n])
 { 
-  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n]; 
-  for (i = 1; i < n; i++) 
+  for (unsigned int i = 1; i < n; i++)
     v[i] = v[i - 1] + m; 
   switch (t)
     {
     case DIAG:
-      for (i = 0; i < n; i++) 
-	for (j = 0; j < m; j++) 
+      for (unsigned int i = 0; i < n; i++)
+	for (unsigned int j = 0; j < m; j++)
 	  if (i != j)
 	    v[i][j] = o; 
 	  else
@@ -972,16 +968,15 @@ template <class T>
 Matrix<T>::Matrix(MType t, const Vector<T>& a, const T& o, unsigned int n, unsigned int m) 
   : v(new T*[n])
 { 
-  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n]; 
-  for (i = 1; i < n; i++) 
+  for (unsigned int i = 1; i < n; i++)
     v[i] = v[i - 1] + m; 
   switch (t)
     {
     case DIAG:
-      for (i = 0; i < n; i++) 
-	for (j = 0; j < m; j++) 
+      for (unsigned int i = 0; i < n; i++)
+	for (unsigned int j = 0; j < m; j++)
 	  if (i != j)
 	    v[i][j] = o; 
 	  else
@@ -996,13 +991,12 @@ template <typename T>
 Matrix<T>::Matrix(const Matrix<T>& rhs)
   : v(new T*[rhs.n])
 {
-  unsigned int i, j;
   n = rhs.n; m = rhs.m;
   v[0] = new T[m * n]; 
-  for (i = 1; i < n; i++) 
+  for (unsigned int i = 1; i < n; i++)
     v[i] = v[i - 1] + m;
-  for (i = 0; i < n; i++)
-    for (j = 0; j < m; j++)
+  for (unsigned int i = 0; i < n; i++)
+    for (unsigned int j = 0; j < m; j++)
       v[i][j] = rhs[i][j];
 }
 
@@ -1021,12 +1015,11 @@ inline Matrix<T>& Matrix<T>::operator=(const Matrix<T> &rhs)
 // if matrix and rhs were different sizes, matrix 
 // has been resized to match the size of rhs 
 { 
-  unsigned int i, j;
   if (this != &rhs) 
     {
       resize(rhs.n, rhs.m);
-      for (i = 0; i < n; i++) 
-	for (j = 0; j < m; j++) 
+      for (unsigned int i = 0; i < n; i++)
+	for (unsigned int j = 0; j < m; j++)
 	  v[i][j] = rhs[i][j]; 
     } 
   return *this; 
@@ -1035,9 +1028,8 @@ inline Matrix<T>& Matrix<T>::operator=(const Matrix<T> &rhs)
 template <typename T> 
 inline Matrix<T>& Matrix<T>::operator=(const T& a) // assign a to every element 
 { 
-  unsigned int i, j;
-  for (i = 0; i < n; i++) 
-    for (j = 0; j < m; j++) 
+  for (unsigned int i = 0; i < n; i++)
+    for (unsigned int j = 0; j < m; j++)
       v[i][j] = a; 
   return *this; 
 } 
@@ -1046,7 +1038,6 @@ inline Matrix<T>& Matrix<T>::operator=(const T& a) // assign a to every element
 template <typename T> 
 inline void Matrix<T>::resize(const unsigned int n, const unsigned int m) 
 {
-  unsigned int i;
   if (n == this->n && m == this->m)
     return;
   if (v != 0) 
@@ -1057,17 +1048,16 @@ inline void Matrix<T>::resize(const unsigned int n, const unsigned int m)
   this->n = n; this->m = m;
   v = new T*[n]; 
   v[0] = new T[m * n];  
-  for (i = 1; i < n; i++)
+  for (unsigned int i = 1; i < n; i++)
     v[i] = v[i - 1] + m;
 } 
 
 template <typename T> 
 inline void Matrix<T>::resize(const T& a, const unsigned int n, const unsigned int m) 
 {
-  unsigned int i, j;
   resize(n, m);
-  for (i = 0; i < n; i++)
-    for (j = 0; j < m; j++)
+  for (unsigned int i = 0; i < n; i++)
+    for (unsigned int j = 0; j < m; j++)
       v[i][j] = a;
 } 
 
@@ -1086,12 +1076,11 @@ inline Vector<T> Matrix<T>::extractRow(const unsigned int i) const
 template <typename T> 
 inline Vector<T> Matrix<T>::extractColumn(const unsigned int j) const
 {
-  unsigned int i;
   if (j >= m)
     throw std::logic_error("Error in extractRow: trying to extract a row out of matrix bounds");
   Vector<T> tmp(n);
 	
-  for (i = 0; i < n; i++)
+  for (unsigned int i = 0; i < n; i++)
     tmp[i] = v[i][j];
 	
   return tmp;
@@ -1100,11 +1089,11 @@ inline Vector<T> Matrix<T>::extractColumn(const unsigned int j) const
 template <typename T>
 inline Vector<T> Matrix<T>::extractDiag() const
 {
-  unsigned int d = std::min(n, m), i;
+  unsigned int d = std::min(n, m);
   
   Vector<T> tmp(d);
 	
-  for (i = 0; i < d; i++)
+  for (unsigned int i = 0; i < d; i++)
     tmp[i] = v[i][i];
 	
   return tmp;
@@ -1115,11 +1104,11 @@ template <typename T>
 inline Matrix<T> Matrix<T>::extractRows(const std::set<unsigned int>& indexes) const
 {
   Matrix<T> tmp(indexes.size(), m);
-  unsigned int i = 0, j;
+  unsigned int i = 0;
 	
   for (std::set<unsigned int>::const_iterator el = indexes.begin(); el != indexes.end(); el++)
     {
-      for (j = 0; j < m; j++)
+      for (unsigned int j = 0; j < m; j++)
 	{
 	  if (*el >= n)
 	    throw std::logic_error("Error extracting rows: the indexes are out of matrix bounds");
@@ -1135,11 +1124,11 @@ template <typename T>
 inline Matrix<T> Matrix<T>::extractColumns(const std::set<unsigned int>& indexes) const
 {
   Matrix<T> tmp(n, indexes.size());
-  unsigned int i, j = 0;
+  unsigned int j = 0;
 	
   for (std::set<unsigned int>::const_iterator el = indexes.begin(); el != indexes.end(); el++)
     {
-      for (i = 0; i < n; i++)
+      for (unsigned int i = 0; i < n; i++)
 	{
 	  if (*el >= m)
 	    throw std::logic_error("Error extracting columns: the indexes are out of matrix bounds");
@@ -2057,16 +2046,16 @@ void cholesky(const Matrix<T> A, Matrix<T>& LL)
 {
   if (A.ncols() != A.nrows())
     throw std::logic_error("Error in Cholesky decomposition: matrix must be squared");
-  int i, j, k, n = A.ncols();
+  int n = A.ncols();
   double sum;
   LL = A;
 	
-  for (i = 0; i < n; i++)
+  for (unsigned int i = 0; i < n; i++)
     {
-      for (j = i; j < n; j++)
+      for (unsigned int j = i; j < n; j++)
 	{
 	  sum = LL[i][j];
-	  for (k = i - 1; k >= 0; k--)
+	  for (int k = i - 1; k >= 0; k--)
 	    sum -= LL[i][k] * LL[j][k];
 	  if (i == j) 
 	    {
@@ -2077,7 +2066,7 @@ void cholesky(const Matrix<T> A, Matrix<T>& LL)
 	  else
 	    LL[j][i] = sum / LL[i][i];
 	}
-      for (k = i + 1; k < n; k++)
+      for (unsigned int k = i + 1; k < n; k++)
 	LL[i][k] = LL[k][i];
     } 
 }
@@ -2122,14 +2111,14 @@ void forward_elimination(const Matrix<T>& L, Vector<T>& y, const Vector<T> b)
     throw std::logic_error("Error in Forward elimination: matrix must be squared (lower triangular)");
   if (b.size() != L.nrows())
     throw std::logic_error("Error in Forward elimination: b vector must be of the same dimensions of L matrix");
-  int i, j, n = b.size();
+  unsigned int n = b.size();
   y.resize(n);
 	
   y[0] = b[0] / L[0][0];
-  for (i = 1; i < n; i++)
+  for (unsigned int i = 1; i < n; i++)
     {
       y[i] = b[i];
-      for (j = 0; j < i; j++)
+      for (unsigned int j = 0; j < i; j++)
 	y[i] -= L[i][j] * y[j];
       y[i] = y[i] / L[i][i];
     }
@@ -2151,14 +2140,14 @@ void backward_elimination(const Matrix<T>& U, Vector<T>& x, const Vector<T>& y)
     throw std::logic_error("Error in Backward elimination: matrix must be squared (upper triangular)");
   if (y.size() != U.nrows())
     throw std::logic_error("Error in Backward elimination: b vector must be of the same dimensions of U matrix");
-  int i, j, n = y.size();
+  int n = y.size();
   x.resize(n);
 	
   x[n - 1] = y[n - 1] / U[n - 1][n - 1];
-  for (i = n - 2; i >= 0; i--)
+  for (int i = n - 2; i >= 0; i--)
     {
       x[i] = y[i];
-      for (j = i + 1; j < n; j++)
+      for (int j = i + 1; j < n; j++)
 	x[i] -= U[i][j] * x[j];
       x[i] = x[i] / U[i][i];
     }

--- a/src/Array.hh
+++ b/src/Array.hh
@@ -909,7 +909,7 @@ template <typename T>
 Matrix<T>::Matrix(unsigned int n, unsigned int m)
   : v(new T*[n])
 {
-  register unsigned int i;
+  unsigned int i;
   this->n = n; this->m = m;
   v[0] = new T[m * n];
   for (i = 1; i < n; i++)
@@ -920,7 +920,7 @@ template <typename T>
 Matrix<T>::Matrix(const T& a, unsigned int n, unsigned int m)
   : v(new T*[n])
 {
-  register unsigned int i, j;
+  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n];
   for (i = 1; i < n; i++)
@@ -934,7 +934,7 @@ template <class T>
 Matrix<T>::Matrix(const T* a, unsigned int n, unsigned int m) 
   : v(new T*[n])
 { 
-  register unsigned int i, j;
+  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n]; 
   for (i = 1; i < n; i++) 
@@ -948,7 +948,7 @@ template <class T>
 Matrix<T>::Matrix(MType t, const T& a, const T& o, unsigned int n, unsigned int m) 
   : v(new T*[n])
 { 
-  register unsigned int i, j;
+  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n]; 
   for (i = 1; i < n; i++) 
@@ -972,7 +972,7 @@ template <class T>
 Matrix<T>::Matrix(MType t, const Vector<T>& a, const T& o, unsigned int n, unsigned int m) 
   : v(new T*[n])
 { 
-  register unsigned int i, j;
+  unsigned int i, j;
   this->n = n; this->m = m;
   v[0] = new T[m * n]; 
   for (i = 1; i < n; i++) 
@@ -996,7 +996,7 @@ template <typename T>
 Matrix<T>::Matrix(const Matrix<T>& rhs)
   : v(new T*[rhs.n])
 {
-  register unsigned int i, j;
+  unsigned int i, j;
   n = rhs.n; m = rhs.m;
   v[0] = new T[m * n]; 
   for (i = 1; i < n; i++) 
@@ -1021,7 +1021,7 @@ inline Matrix<T>& Matrix<T>::operator=(const Matrix<T> &rhs)
 // if matrix and rhs were different sizes, matrix 
 // has been resized to match the size of rhs 
 { 
-  register unsigned int i, j;
+  unsigned int i, j;
   if (this != &rhs) 
     {
       resize(rhs.n, rhs.m);
@@ -1035,7 +1035,7 @@ inline Matrix<T>& Matrix<T>::operator=(const Matrix<T> &rhs)
 template <typename T> 
 inline Matrix<T>& Matrix<T>::operator=(const T& a) // assign a to every element 
 { 
-  register unsigned int i, j;
+  unsigned int i, j;
   for (i = 0; i < n; i++) 
     for (j = 0; j < m; j++) 
       v[i][j] = a; 
@@ -1046,7 +1046,7 @@ inline Matrix<T>& Matrix<T>::operator=(const T& a) // assign a to every element
 template <typename T> 
 inline void Matrix<T>::resize(const unsigned int n, const unsigned int m) 
 {
-  register unsigned int i;
+  unsigned int i;
   if (n == this->n && m == this->m)
     return;
   if (v != 0) 
@@ -1064,7 +1064,7 @@ inline void Matrix<T>::resize(const unsigned int n, const unsigned int m)
 template <typename T> 
 inline void Matrix<T>::resize(const T& a, const unsigned int n, const unsigned int m) 
 {
-  register unsigned int i, j;
+  unsigned int i, j;
   resize(n, m);
   for (i = 0; i < n; i++)
     for (j = 0; j < m; j++)
@@ -1086,7 +1086,7 @@ inline Vector<T> Matrix<T>::extractRow(const unsigned int i) const
 template <typename T> 
 inline Vector<T> Matrix<T>::extractColumn(const unsigned int j) const
 {
-  register unsigned int i;
+  unsigned int i;
   if (j >= m)
     throw std::logic_error("Error in extractRow: trying to extract a row out of matrix bounds");
   Vector<T> tmp(n);
@@ -1100,7 +1100,7 @@ inline Vector<T> Matrix<T>::extractColumn(const unsigned int j) const
 template <typename T>
 inline Vector<T> Matrix<T>::extractDiag() const
 {
-  register unsigned int d = std::min(n, m), i;
+  unsigned int d = std::min(n, m), i;
   
   Vector<T> tmp(d);
 	
@@ -1115,7 +1115,7 @@ template <typename T>
 inline Matrix<T> Matrix<T>::extractRows(const std::set<unsigned int>& indexes) const
 {
   Matrix<T> tmp(indexes.size(), m);
-  register unsigned int i = 0, j;
+  unsigned int i = 0, j;
 	
   for (std::set<unsigned int>::const_iterator el = indexes.begin(); el != indexes.end(); el++)
     {
@@ -1135,7 +1135,7 @@ template <typename T>
 inline Matrix<T> Matrix<T>::extractColumns(const std::set<unsigned int>& indexes) const
 {
   Matrix<T> tmp(n, indexes.size());
-  register unsigned int i, j = 0;
+  unsigned int i, j = 0;
 	
   for (std::set<unsigned int>::const_iterator el = indexes.begin(); el != indexes.end(); el++)
     {
@@ -1155,7 +1155,7 @@ template <typename T>
 inline Matrix<T> Matrix<T>::extract(const std::set<unsigned int>& r_indexes, const std::set<unsigned int>& c_indexes) const
 {
   Matrix<T> tmp(r_indexes.size(), c_indexes.size());
-  register unsigned int i = 0, j;
+  unsigned int i = 0, j;
 	
   for (std::set<unsigned int>::const_iterator r_el = r_indexes.begin(); r_el != r_indexes.end(); r_el++)
     {
@@ -2057,8 +2057,8 @@ void cholesky(const Matrix<T> A, Matrix<T>& LL)
 {
   if (A.ncols() != A.nrows())
     throw std::logic_error("Error in Cholesky decomposition: matrix must be squared");
-  register int i, j, k, n = A.ncols();
-  register double sum;
+  int i, j, k, n = A.ncols();
+  double sum;
   LL = A;
 	
   for (i = 0; i < n; i++)
@@ -2122,7 +2122,7 @@ void forward_elimination(const Matrix<T>& L, Vector<T>& y, const Vector<T> b)
     throw std::logic_error("Error in Forward elimination: matrix must be squared (lower triangular)");
   if (b.size() != L.nrows())
     throw std::logic_error("Error in Forward elimination: b vector must be of the same dimensions of L matrix");
-  register int i, j, n = b.size();
+  int i, j, n = b.size();
   y.resize(n);
 	
   y[0] = b[0] / L[0][0];
@@ -2151,7 +2151,7 @@ void backward_elimination(const Matrix<T>& U, Vector<T>& x, const Vector<T>& y)
     throw std::logic_error("Error in Backward elimination: matrix must be squared (upper triangular)");
   if (y.size() != U.nrows())
     throw std::logic_error("Error in Backward elimination: b vector must be of the same dimensions of U matrix");
-  register int i, j, n = y.size();
+  int i, j, n = y.size();
   x.resize(n);
 	
   x[n - 1] = y[n - 1] / U[n - 1][n - 1];


### PR DESCRIPTION
Variable declaration with the `register` keyword was deprecated in C++11 and removed in C++17.
https://en.cppreference.com/w/cpp/language/storage_duration

This means that, if a QuadProg++ user uses C++17, she cannot include the header `QuadProg++/QuadProg++.hh` in her codes in a standard way. To ignore `register` by overriding it, she may need to write something like: 
```
#if __cplusplus >= 201703L
#define register
#endif
```
before she includes the header file, which is awkward.

I think there are two ways to solve this problem:

- Remove `register` from the public header files.
- Add the macro above before the first `register` appears.

I suggest taking the former solution because it is often said that the `register` keyword is likely to be ignored by recent compilers (they could optimize codes better than humans).

Note that having `register` in `.cc` files is fine as it can be compiled using older C++. So I leave it as it is.