### PR TITLE
Fix warnings from compilation

### DIFF
--- a/src/QuadProg++.cc
+++ b/src/QuadProg++.cc
@@ -95,12 +95,11 @@ double solve_quadprog(Matrix<double>& G, Vector<double>& g0,
   double t, t1, t2; /* t is the step lenght, which is the minimum of the partial step length t1 
     * and the full step length t2 */
   Vector<int> A(m + p), A_old(m + p), iai(m + p);
-  unsigned int q, iq, iter = 0;
+  unsigned int iq, iter = 0;
   Vector<bool> iaexcl(m + p);
 	
   /* p is the number of equality constraints */
   /* m is the number of inequality constraints */
-  q = 0;  /* size of the active set A (containing the indices of the active constraints) */
 #ifdef TRACE_SOLVER
   std::cout << std::endl << "Starting solve_quadprog" << std::endl;
   print_matrix("G", G);
@@ -247,7 +246,7 @@ l1:	iter++;
   if (fabs(psi) <= m * std::numeric_limits<double>::epsilon() * c1 * c2* 100.0)
   {
     /* numerically there are not infeasibilities anymore */
-    q = iq;
+//    q = iq;
     
     return f_value;
   }
@@ -273,7 +272,7 @@ l2: /* Step 2: check for feasibility and determine a new S-pair */
     }
   if (ss >= 0.0)
   {
-    q = iq;
+//    q = iq;
     
     return f_value;
   }
@@ -345,7 +344,6 @@ l2a:/* Step 2a: determine step direction */
   {
     /* QPP is infeasible */
     // FIXME: unbounded to raise
-    q = iq;
     return inf;
   }
   /* case (ii): step in dual space */

--- a/src/QuadProg++.cc
+++ b/src/QuadProg++.cc
@@ -26,8 +26,8 @@ namespace quadprogpp {
 void compute_d(Vector<double>& d, const Matrix<double>& J, const Vector<double>& np);
 void update_z(Vector<double>& z, const Matrix<double>& J, const Vector<double>& d, int iq);
 void update_r(const Matrix<double>& R, Vector<double>& r, const Vector<double>& d, int iq);
-bool add_constraint(Matrix<double>& R, Matrix<double>& J, Vector<double>& d, int& iq, double& rnorm);
-void delete_constraint(Matrix<double>& R, Matrix<double>& J, Vector<int>& A, Vector<double>& u, int n, int p, int& iq, int l);
+bool add_constraint(Matrix<double>& R, Matrix<double>& J, Vector<double>& d, unsigned int& iq, double& rnorm);
+void delete_constraint(Matrix<double>& R, Matrix<double>& J, Vector<int>& A, Vector<double>& u, int n, int p, unsigned int& iq, int l);
 
 // Utility functions for computing the Cholesky decomposition and solving
 // linear systems
@@ -55,7 +55,7 @@ double solve_quadprog(Matrix<double>& G, Vector<double>& g0,
                       Vector<double>& x)
 {
   std::ostringstream msg;
-  int n = G.ncols(), p = CE.ncols(), m = CI.ncols();
+  unsigned int n = G.ncols(), p = CE.ncols(), m = CI.ncols();
   if (G.nrows() != n)
   {
     msg << "The matrix G is not a squared matrix (" << G.nrows() << " x " << G.ncols() << ")";
@@ -82,7 +82,7 @@ double solve_quadprog(Matrix<double>& G, Vector<double>& g0,
     throw std::logic_error(msg.str());
   }
   x.resize(n);
-  register int i, j, k, l; /* indices */
+  register unsigned int i, j, k, l; /* indices */
   int ip; // this is the index of the constraint to be added to the active set
   Matrix<double> R(n, n), J(n, n);
   Vector<double> s(m + p), z(n), r(m + p), d(n), np(n), u(m + p), x_old(n), u_old(m + p);
@@ -95,7 +95,7 @@ double solve_quadprog(Matrix<double>& G, Vector<double>& g0,
   double t, t1, t2; /* t is the step lenght, which is the minimum of the partial step length t1 
     * and the full step length t2 */
   Vector<int> A(m + p), A_old(m + p), iai(m + p);
-  int q, iq, iter = 0;
+  unsigned int q, iq, iter = 0;
   Vector<bool> iaexcl(m + p);
 	
   /* p is the number of equality constraints */


### PR DESCRIPTION
This fixes warnings when compiling QuadProgpp.

* There are comparisons between signed and unsigned integers
* A variable 'q' is initialized and set in several places but is never read / used
* There is no checking if delete_constraint finds the given constraint and it looks like it ends up executing some undefined logic if that is the case (it will proceed with a found index of -1 which looks bad). For this problem (since it is no longer possible to set unsigned int to -1) I used an extra boolean flag to make the logic throw an exception if the given constraint was not found.

I manually tested the "main" before and after these changes and the output is identical. There were no other tests to execute.