### PR TITLE
Make CI,ci0 in example non-degenerate to RowMajor / ColMajor

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -15,8 +15,8 @@
  s.t.
    x_1 + x_2 = 3
    x_1 >= 0
-   x_2 >= 0
    x_1 + x_2 >= 2
+   x_2 >= 0
  
  The solution is x^T = [1 2] and f(x) = 12
  
@@ -84,7 +84,7 @@ int main (int argc, char *const argv[]) {
 	p = 3;
   CI.resize(n, p);
   {
-		std::istringstream is("1.0, 0.0, 1.0, "
+		std::istringstream is("1.0, 1.0, 0.0, "
 													"0.0, 1.0, 1.0 ");
   
 		for (int i = 0; i < n; i++)
@@ -94,7 +94,7 @@ int main (int argc, char *const argv[]) {
   
   ci0.resize(p);
   {
-		std::istringstream is("0.0, 0.0, -2.0 ");
+		std::istringstream is("0.0,-2.0,  0.0 ");
 
 		for (int j = 0; j < p; j++)
 			is >> ci0[j] >> ch;


### PR DESCRIPTION
The example in `src/main.cc` (accidentally) works even if matrices are passed in [column major order](https://en.wikipedia.org/wiki/Row-_and_column-major_order) instead of QuadProg++'s expected row major order. `H` is symmetric so under doesn't matter. Likewise, `CE` is 1x1. But `CI` is a rectangular matrix and passing its entries in the wrong order (with `ci0` left as is), will produce a correct result. As a result I got this example running and then assumed QuadProg++ was using Column Major ordering (doh!).

Not sure many people will run into the same issue as me, but just in case: here's a tiny fix that simply permutes the order of the constraints in `CI` and `ci0` in the example so that using column major will not produce the same result (and in fact will make the problem infeasible).