### PR TITLE
CMakeLists.txt: fix cmake-4 build (raise minimum version to 3.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(QuadProg++ CXX)
 


### PR DESCRIPTION
Without the change the build on cmake-4 fails as:

    CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
      Compatibility with CMake < 3.5 has been removed from CMake.